### PR TITLE
AWS amplify deployment

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted

--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 
 ### Why pnpm?
 We chose to use pnpm for its improved security over npm, and also its improved package management speed compared to yarn. Read more [here](https://hackernoon.com/choosing-the-right-package-manager-npm-yarn-or-pnpm). 
+
+Build setting specifications:
+
+* Changed node version to 20 to be compatible with building next.js applications to fulfil requirement >=18.17.0
+* Changed container image to be Amazon linux 2023 to solve GLIBC_2.28 not found error after upgrading node version.
+* Added npmrc file as a linker between pnpm and npm because amplify does some part of its installation using npm here

--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 ### Why pnpm?
 We chose to use pnpm for its improved security over npm, and also its improved package management speed compared to yarn. Read more [here](https://hackernoon.com/choosing-the-right-package-manager-npm-yarn-or-pnpm). 
 
-Build setting specifications:
+### Deployment
 
+This project has been integrated with the AWS amplify github app for automatic deployments. All commits and pull requests to the ```develop``` branch have been set up for automatic deployment. Deployment and build settings should be edited through the AWS Amplify [console](https://console.aws.amazon.com/amplify/home) and through associated [documentation](https://docs.aws.amazon.com/amplify/latest/userguide/getting-started.html). 
+
+Deployment build setting specifications:
 * Changed node version to 20 to be compatible with building next.js applications to fulfil requirement >=18.17.0
-* Changed container image to be Amazon linux 2023 to solve GLIBC_2.28 not found error after upgrading node version.
-* Added npmrc file as a linker between pnpm and npm because amplify does some part of its installation using npm here
+* Changed container image to be Amazon linux 2023 to solve [GLIBC_2.28 not found](https://stackoverflow.com/questions/72921215/getting-glibc-2-28-not-found) error after upgrading node version.
+* Added npmrc file as a linker between pnpm and npm because amplify does some part of its installation using npm [here](https://docs.aws.amazon.com/amplify/latest/userguide/monorepo-configuration.html#turborepo-pnpm-monorepo-configuration).
+* Since repository is public, AWS amplify app has no linked IAM service roles for [security purposes](https://docs.aws.amazon.com/amplify/latest/userguide/pr-previews.html) to enable pull request previews. 


### PR DESCRIPTION
Build setting specifications:
* Changed node version to 20 to be compatible with building next.js applications to fulfil requirement >=18.17.0
* Changed container image to be Amazon linux 2023 to solve [GLIBC_2.28 not found](https://stackoverflow.com/questions/72921215/getting-glibc-2-28-not-found) error after upgrading node version.
* Added npmrc file as a linker between pnpm and npm because amplify does some part of its installation using npm [here](https://docs.aws.amazon.com/amplify/latest/userguide/monorepo-configuration.html#turborepo-pnpm-monorepo-configuration).